### PR TITLE
feat: IDベース重複チェック実装 (#12)

### DIFF
--- a/src/__tests__/duplicate-check.test.ts
+++ b/src/__tests__/duplicate-check.test.ts
@@ -9,17 +9,17 @@ describe('findNoteByGmapId', () => {
     { path: 'Google Maps/Places/NoId.md', gmapId: undefined },
   ]
 
-  test.skip('gmap_id が一致するファイルパスを返す', () => {
+  test('gmap_id が一致するファイルパスを返す', () => {
     const result = findNoteByGmapId(sampleNotes, 'cid-12345678', 'Google Maps/Places')
     expect(result).toBe('Google Maps/Places/東京タワー - 12345678.md')
   })
 
-  test.skip('gmap_id が見つからない場合は null を返す', () => {
+  test('gmap_id が見つからない場合は null を返す', () => {
     const result = findNoteByGmapId(sampleNotes, 'cid-00000000', 'Google Maps/Places')
     expect(result).toBeNull()
   })
 
-  test.skip('指定フォルダ外のファイルは検索対象外', () => {
+  test('指定フォルダ外のファイルは検索対象外', () => {
     const result = findNoteByGmapId(sampleNotes, 'cid-99999999', 'Google Maps/Places')
     expect(result).toBeNull()
   })

--- a/src/duplicate-check.ts
+++ b/src/duplicate-check.ts
@@ -1,6 +1,78 @@
+import type { App } from 'obsidian'
+
 export interface NoteMetadata {
   path: string
   gmapId: string | undefined
+}
+
+/**
+ * 指定フォルダ内の全ノートからfrontmatterのgmap_idを読み込んでNoteMetadataの配列を返す
+ */
+export async function loadNoteMetadata(app: App, folderPrefix: string): Promise<NoteMetadata[]> {
+  const markdownFiles = app.vault.getMarkdownFiles()
+  const metadata: NoteMetadata[] = []
+
+  for (const file of markdownFiles) {
+    // 指定フォルダ内のファイルのみ処理
+    if (!file.path.startsWith(folderPrefix)) {
+      continue
+    }
+
+    // metadataCacheからfrontmatterを取得
+    let gmapId: string | undefined
+    const cache = app.metadataCache.getFileCache(file)
+
+    if (cache?.frontmatter) {
+      // frontmatterからgmap_idを取得（文字列のクォートを除去）
+      const rawGmapId = cache.frontmatter['gmap_id'] as string | undefined
+      if (typeof rawGmapId === 'string') {
+        // YAMLの値からクォートを除去（"cid-123" -> cid-123）
+        gmapId = rawGmapId.replace(/^["']|["']$/g, '')
+      }
+    }
+
+    // frontmatterにない場合はファイルコンテンツから直接抽出を試みる
+    if (!gmapId) {
+      try {
+        const fileContent = await app.vault.read(file)
+        gmapId = extractGmapIdFromContent(fileContent)
+      } catch {
+        // ファイル読み込みエラーは無視
+      }
+    }
+
+    metadata.push({
+      path: file.path,
+      gmapId,
+    })
+  }
+
+  return metadata
+}
+
+/**
+ * ファイルコンテンツからgmap_idを抽出
+ */
+function extractGmapIdFromContent(content: string): string | undefined {
+  // frontmatterブロックを抽出
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!frontmatterMatch) {
+    return undefined
+  }
+
+  const frontmatter = frontmatterMatch[1]
+  if (!frontmatter) {
+    return undefined
+  }
+
+  // gmap_id: "cid-123" または gmap_id: 'cid-123' または gmap_id: cid-123 を検索
+  const gmapIdMatch = frontmatter.match(/^gmap_id:\s*(?:"([^"]+)"|'([^']+)'|(\S+))$/m)
+  if (gmapIdMatch) {
+    // クォートされた値またはクォートなしの値を取得
+    return gmapIdMatch[1] || gmapIdMatch[2] || gmapIdMatch[3]
+  }
+
+  return undefined
 }
 
 /**
@@ -8,9 +80,16 @@ export interface NoteMetadata {
  * @returns 一致するノートのパス、見つからない場合は null
  */
 export function findNoteByGmapId(
-  _notes: NoteMetadata[],
-  _gmapId: string,
-  _folderPrefix: string,
+  notes: NoteMetadata[],
+  gmapId: string,
+  folderPrefix: string,
 ): string | null {
-  throw new Error('Not implemented')
+  for (const note of notes) {
+    // 指定フォルダ内で、gmap_idが一致するノートを検索
+    if (note.path.startsWith(folderPrefix) && note.gmapId === gmapId) {
+      return note.path
+    }
+  }
+
+  return null
 }


### PR DESCRIPTION
## 概要

ファイル名ベースの重複チェックを、gmap_idによるfrontmatter検索に変更しました。

## 変更内容

- `loadNoteMetadata`関数を実装: 指定フォルダ内の全ノートからfrontmatterのgmap_idを読み込む
- `findNoteByGmapId`関数を実装: メタデータ配列から指定のgmap_idを持つノートのパスを検索
- `main.ts`を更新: ファイル名ベースの重複チェック（`exists(filePath)`）をgmap_idベースのチェックに変更
- テストを有効化: `test.skip`を削除し、3つのテストケースを有効化

## 効果

ファイル名が変更された場合でも、gmap_idに基づいて重複ノートの生成を防ぐことができます。

Closes #12